### PR TITLE
fix: bypass attach chip when use power-off method, and skip check be power funcs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -222,6 +222,7 @@ impl Command for GetChipInfo {
 // UID in wchisp: cd-ab-b4-ae-45-bc-c6-16
 // e339e339e339e339 => inital value of erased flash
 /// Chip UID, also reported by wchisp
+#[derive(Clone, PartialEq)]
 pub struct ChipUID(pub [u8; 8]);
 impl Response for ChipUID {
     fn from_raw(resp: &[u8]) -> Result<Self> {
@@ -285,8 +286,7 @@ impl Command for Reset {
 }
 
 /// Speed settings
-#[derive(Debug, Copy, Clone, clap::ValueEnum, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, clap::ValueEnum, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 pub enum Speed {
     /// 400kHz
     Low = 0x03,
@@ -296,7 +296,6 @@ pub enum Speed {
     #[default]
     High = 0x01,
 }
-
 
 /// Set CLK Speed, 0x0C
 #[derive(Debug)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -22,7 +22,7 @@ const ENDPOINT_OUT_DAP: u8 = 0x02;
 // const ENDPOINT_IN_DAP: u8 = 0x83;
 
 /// Attached chip information
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ChipInfo {
     /// UID
     pub uid: Option<ChipUID>,

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -241,16 +241,21 @@ impl WchLink {
     }
 
     /// Clear All Code Flash - By Power off
-    pub fn erase_flash_by_power_off(&mut self) -> Result<()> {
-        let chip_family = self.chip.as_ref().unwrap().chip_family;
-        if self.probe.as_ref().unwrap().variant.support_power_funcs()
-            && chip_family.support_special_erase()
-        {
-            self.send_command(control::EraseCodeFlash::ByPowerOff(chip_family))?;
-            Ok(())
-        } else {
-            Err(Error::Custom("Probe or Chip doesn't support power off erase".to_string()))
+    pub fn erase_flash_by_power_off(&mut self, chip: Option<RiscvChip>) -> Result<()> {
+        let mut chip_family: Option<RiscvChip> = chip;
+        if let Some(chip) = self.chip.as_ref() {
+            chip_family = Some(chip.chip_family)
         }
+
+        if let Some(chip_family) = chip_family {
+            if chip_family.support_special_erase()
+            {
+                self.send_command(control::EraseCodeFlash::ByPowerOff(chip_family))?;
+                return Ok(())
+            }
+        }
+
+        Err(Error::Custom("Probe or Chip doesn't support power off erase".to_string()))
     }
 
     /// Clear All Code Flash - By RST pin


### PR DESCRIPTION
Related issue: https://github.com/ch32-rs/wlink/issues/26

