### PR TITLE
New feature: Serial watch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install libudev for Linux
+      if: runner.os == 'Linux'
+      run: sudo apt-get install libudev-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run help
+      run: cargo run -- --help

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -31,6 +31,9 @@ jobs:
           toolchain: nightly
           components: rustfmt, clippy
           override: true
+      - name: Install libudev for Linux (optional)
+        if: matrix.os == 'Linux'
+        run: sudo apt-get install libudev-dev
       - name: Build
         run: cargo build --release
       - name: Run help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `--watch-serial` for `flash` subcommand
+- Add `--watch-serial` for `flash` subcommand, #36
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--watch-serial` for `flash` subcommand
+
 ### Changed
 
 - No erase by default when flashing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,36 @@
 version = 3
 
 [[package]]
+name = "CoreFoundation-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e9889e6db118d49d88d84728d0e964d973a5680befb5f85f55141beea5c20b"
+dependencies = [
+ "libc",
+ "mach",
+]
+
+[[package]]
+name = "IOKit-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99696c398cbaf669d2368076bdb3d627fb0ce51a26899d7c61228c5c0af3bf4a"
+dependencies = [
+ "CoreFoundation-sys",
+ "libc",
+ "mach",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +91,18 @@ name = "bitfield"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "cc"
@@ -210,6 +252,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libusb1-sys"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,10 +290,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "mach"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd13ee2dd61cc82833ba05ade5a30bb3d63f7ced605ef827063c63078302de9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -312,6 +403,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "rusb"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +440,12 @@ dependencies = [
  "libc",
  "libusb1-sys",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -339,6 +465,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serialport"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c32634e2bd4311420caa504404a55fad2131292c485c97014cbed89a5899885f"
+dependencies = [
+ "CoreFoundation-sys",
+ "IOKit-sys",
+ "bitflags 2.0.2",
+ "cfg-if",
+ "libudev",
+ "mach2",
+ "nix",
+ "regex",
+ "scopeguard",
+ "winapi",
 ]
 
 [[package]]
@@ -630,6 +774,7 @@ dependencies = [
  "nu-pretty-hex",
  "object",
  "rusb",
+ "serialport",
  "simplelog",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libusb1-sys"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +477,7 @@ dependencies = [
  "IOKit-sys",
  "bitflags 2.0.2",
  "cfg-if",
+ "libudev",
  "mach2",
  "nix",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,26 +252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libusb1-sys"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,7 +457,6 @@ dependencies = [
  "IOKit-sys",
  "bitflags 2.0.2",
  "cfg-if",
- "libudev",
  "mach2",
  "nix",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ object = { version = "0.32", default-features = false, features = [
     "std",
 ] }
 indicatif = "0.17.7"
-serialport = { version = "4.2.2" }
+serialport = { version = "4.2.2", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["embedded", "WCH", "CH32V", "WCH-Link"]
 readme = "README.md"
 license = "MIT/Apache-2.0"
 
+[features]
+default = []
+
 [dependencies]
 anyhow = "1.0.68"
 bitfield = "0.14.0"
@@ -29,3 +32,4 @@ object = { version = "0.32", default-features = false, features = [
     "std",
 ] }
 indicatif = "0.17.7"
+serialport = { version = "4.2.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ object = { version = "0.32", default-features = false, features = [
     "std",
 ] }
 indicatif = "0.17.7"
-serialport = { version = "4.2.2", default-features = false}
+serialport = "4.2.2"

--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@
 [docsrs]: https://docs.rs/wlink
 [nightly]: https://github.com/ch32-rs/wlink/releases/tag/nightly
 
-**NOTE**: This tool is still in development and not ready for production use.
+> **Note**
+> This tool is still in development and not ready for production use.
 
 ## Feature Support
 
 - [x] Flash firmware, support Intel HEX, ELF and raw binary format
 - [x] Erase chip
+- [x] Halt, resume, reset support
 - [x] Read chip info
-- [x] Read chip memory
-- [x] Read chip register
-- [x] Write chip register
+- [x] Read chip memory(flash)
+- [x] Read/write chip register - very handy for debugging
 - [x] Code-Protect & Code-Unprotect for supported chips
-- [x] [SDI print](https://www.cnblogs.com/liaigu/p/17628184.html) support
+- [x] [SDI print](https://www.cnblogs.com/liaigu/p/17628184.html) support, requires 2.10+ firmware
+- [x] Serial port watching(#36) for a smooth development experience
 
 ## Tested On
 
@@ -77,7 +79,14 @@ Current firmware version: 2.11 (aka. v31).
 
 `cargo install --git https://github.com/ch32-rs/wlink` or download a binary from the [Nightly Release page](https://github.com/ch32-rs/wlink/releases/tag/nightly).
 
+> **Note**
+> On Linux, you should install libudev and libusb development lib first.
+> Like `sudo apt install libudev-dev libusb-1.0-0-dev` on Ubuntu.
+
 ## Usage
+
+> **Note**
+> For help of wire connection for specific chips, please refer to `docs` subdirectory.
 
 ```console
 > # Flash firmware.bin to Code FLASH at address 0x08000000
@@ -88,6 +97,21 @@ Current firmware version: 2.11 (aka. v31).
 12:10:27 [INFO] Flash done
 12:10:28 [INFO] Now reset...
 12:10:28 [INFO] Resume executing...
+
+> # Flash firmware.bin to System FLASH, enable SDI print, then watch serial port
+> wlink flash --enable-sdi-print --watch-serial firmware.bin
+02:54:34 [INFO] WCH-Link v2.11 (WCH-LinkE-CH32V305)
+02:54:34 [INFO] Attached chip: CH32V003 [CH32V003F4P6] (ChipID: 0x00300500)
+02:54:34 [INFO] Flash already unprotected
+02:54:34 [INFO] Flash protected: false
+02:54:35 [INFO] Flash done
+02:54:35 [INFO] Now reset...
+02:54:35 [INFO] Now connect to the WCH-Link serial port to read SDI print
+Hello world from ch32v003 SDI print!
+led toggle
+led toggle
+...
+
 
 > # Dump Code FLASH, for verification
 > # use `-v` or `-vv` for more logs
@@ -109,9 +133,11 @@ Current firmware version: 2.11 (aka. v31).
 08000050:   f3 23 40 f1  b7 02 00 00  93 82 02 00  63 f4 72 00   ×#@××•00××•0c×r0
 08000060:   6f 00 c0 29                                          o0×)
 
+
 > # Dump System FLASH, BOOT_28KB
 > wlink dump 0x1FFF8000 0x7000
 ....
+
 
 > # Dump all general purpose registers
 > wlink regs

--- a/src/commands/control.rs
+++ b/src/commands/control.rs
@@ -181,13 +181,15 @@ impl Command for SetPower {
 }
 
 /// SDI print support, only avaliable for WCH-LinkE
+/// Firmware version >= 2.10
 #[derive(Debug)]
 pub enum SetSDIPrint {
     Enable,
     Disable,
 }
 impl Command for SetSDIPrint {
-    type Response = ();
+    // 0x00 success, 0xff not support
+    type Response = u8;
     const COMMAND_ID: u8 = 0x0d;
     fn payload(&self) -> Vec<u8> {
         match self {

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,8 +9,8 @@ use crate::{
     Result, RiscvChip,
 };
 
-const VENDOR_ID: u16 = 0x1a86;
-const PRODUCT_ID: u16 = 0x8010;
+pub const VENDOR_ID: u16 = 0x1a86;
+pub const PRODUCT_ID: u16 = 0x8010;
 
 const ENDPOINT_OUT: u8 = 0x01;
 const ENDPOINT_IN: u8 = 0x81;

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,10 @@ pub enum Error {
     DmiFailed,
     #[error("Operation timeout")]
     Timeout,
+    #[error("Serial port error: {0}")]
+    Serial(#[from] serialport::Error),
+    #[error("Io error: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/format.rs
+++ b/src/format.rs
@@ -123,7 +123,7 @@ pub fn objcopy_binary(elf_data: &[u8]) -> Result<Vec<u8>> {
             .data(endian, elf_data)
             .map_err(|_| anyhow::format_err!("Failed to access data for an ELF segment."))?;
         if !segment_data.is_empty() && segment.p_type(endian) == PT_LOAD {
-            log::info!(
+            log::debug!(
                     "Found loadable segment, physical address: {:#010x}, virtual address: {:#010x}, flags: {:#x}",
                     p_paddr,
                     p_vaddr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod dmi;
 pub mod error;
 pub mod flash_op;
 pub mod format;
-mod operations;
+pub mod operations;
 pub mod regs;
 pub mod transport;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,9 @@ enum Commands {
         /// Enable SDI print after reset
         #[arg(long, default_value = "false")]
         enable_sdi_print: bool,
+        /// Open serial port(print only) after reset
+        #[arg(long, default_value = "false")]
+        watch_serial: bool,
         /// Path to the firmware file to flash
         path: String,
     },
@@ -310,6 +313,7 @@ fn main() -> Result<()> {
                     no_run,
                     path,
                     enable_sdi_print,
+                    watch_serial,
                 } => {
                     probe.dump_info(false)?;
 
@@ -339,9 +343,13 @@ fn main() -> Result<()> {
                         if enable_sdi_print {
                             probe.enable_sdi_print(true)?;
                             will_detach = false;
-                            log::info!("Now you can connect to the WCH-Link serial port");
+                            log::info!("Now connect to the WCH-Link serial port to read SDI print");
                         }
-                        sleep(Duration::from_millis(500));
+                        if watch_serial {
+                            wlink::operations::watch_serial()?;
+                        } else {
+                            sleep(Duration::from_millis(500));
+                        }
                     }
                 }
                 Unprotect {} => {


### PR DESCRIPTION
This is designed to print serial logs.

- Can be used with `--enable-sdi-print` for a smooth dev experience
- Can be used with UART print

Usage:

    wlink -v flash --enable-sdi-print --watch-serial xxx.bin

```console
> wlink flash --enable-sdi-print --watch-serial target/riscv32ec-unknown-none-elf/release/examples/sdi-debug
16:04:37 [INFO] WCH-Link v2.11 (WCH-LinkE-CH32V305)
16:04:37 [INFO] Attached chip: CH32V003 [CH32V003F4P6] (ChipID: 0x00300500)
16:04:37 [INFO] Chip UID: cd-ab-80-17-48-bc-95-7f
16:04:37 [INFO] Flash protected: false
16:04:37 [INFO] Read target/riscv32ec-unknown-none-elf/release/examples/debug as ELF format
16:04:37 [INFO] Firmware size: 4037, start_address: 0x00000000, end_address: 0x00000fc5
16:04:37 [INFO] Flashing 4037 bytes to 0x08000000
16:04:37 [INFO] WCH-Link v2.11 (WCH-LinkE-CH32V305)
16:04:37 [INFO] Attached chip: CH32V003 [CH32V003F4P6] (ChipID: 0x00300500)
16:04:37 [INFO] Flash already unprotected
16:04:37 [INFO] Flash protected: false
16:04:38 [INFO] Flash done
16:04:38 [INFO] Now reset...
16:04:38 [INFO] Now connect to the WCH-Link serial port to read SDI print
gle
Hello world from ch32v003 SDI print!
led toggle
led toggle
led toggle
^C
>
```

Note that "gle" is from previous content(before reset).