### PR TITLE
Feature: dump memory region to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `--watch-serial` for `flash` subcommand, #36
+- Add `-o/--out` for `dump` sumcommand, #38
 
 ### Changed
 


### PR DESCRIPTION
This adds the option to dump a memory region to a binary file using the `dump` command. If the file specified in the command already exists, it doesn't overwrite the file, only when the `--override` option is specified.

I couldn't figure out how to make the `--file` option an optional argument, thats why I specify the default value as an empty string and check in the command handler if a different value than an empty string is present. Maybe you know how to make the `--file` option an optional argument instead of a required argument with a default value?