### PR TITLE
Change --help output to list all possible choices for --chip

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,13 @@ pub mod probe;
 pub mod regs;
 pub mod usb_device;
 
+use clap::ValueEnum;
 use probe::WchLink;
 
 pub use crate::error::{Error, Result};
 
 /// Currently supported RISC-V chip series/family
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 #[repr(u8)]
 pub enum RiscvChip {
     /// CH32V103 RISC-V3A series

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct Cli {
     no_detach: bool,
 
     /// Specify the chip type, e.g. CH32V30X
-    #[arg(long, global = true)]
+    #[arg(long, global = true, ignore_case = true)]
     chip: Option<RiscvChip>,
 
     /// Connection Speed


### PR DESCRIPTION
Also, make the parsing of the argument to --chip be case-insensitive

New `--help` output:
```
$ ./target/debug/wlink --help
WCH-Link flash tool for WCH's RISC-V MCUs(CH32V, CH56X, CH57X, CH58X, CH59X, CH32L103, CH32X035, CH641, CH643)

Usage: wlink [OPTIONS] [COMMAND]

Commands:
  dump         Dump memory region
  regs         Dump registers
  erase        Erase flash
  flash        Program the code flash
  unprotect    Unlock flash
  protect      Protect flash
  write-reg    Force set register
  write-mem    Force write a memory word
  halt         Halts the MCU
  resume       Resumes the MCU
  reset        Reset the MCU
  status       Debug, check status
  mode-switch  Swifth mode from RV to DAP or vice versa
  sdi-print    SDI virtual serial port,
  dev          
  help         Print this message or the help of the given subcommand(s)

Options:
  -d, --device <INDEX>
          Optional device index to operate on

  -v, --verbose...
          Turn debugging information on

      --no-detach
          Detach chip after operation

      --chip <CHIP>
          Specify the chip type, e.g. CH32V30X

          Possible values:
          - ch32v103: CH32V103 RISC-V3A series
          - ch57x:    CH571/CH573 RISC-V3A BLE 4.2 series
          - ch56x:    CH565/CH569 RISC-V3A series
          - ch32v20x: CH32V20X RISC-V4B/V4C series
          - ch32v30x: CH32V30X RISC-V4C/V4F series, The same as type 5
          - ch58x:    CH58x RISC-V4A BLE 5.3 series
          - ch32v003: CH32V003 RISC-V2A series
          - ch8571:   RISC-V EC controller, undocumented
          - ch59x:    CH59x RISC-V4C BLE 5.4 series, fallback as CH58X
          - ch643:    CH643 RISC-V4C series, RGB Display Driver MCU
          - ch32x035: CH32X035 RISC-V4C USB-PD series, fallbak as CH643
          - ch32l103: CH32L103 RISC-V4C low power series, USB-PD
          - ch641:    CH641 RISC-V2A series, USB-PD, fallback as CH32V003

      --speed <SPEED>
          Connection Speed
          
          [default: high]

          Possible values:
          - low:    400kHz
          - medium: 4000kHz
          - high:   6000kHz

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```