### PR TITLE
Ensure consistent nanosecond precision in log timestamps

### DIFF
--- a/src/probe.rs
+++ b/src/probe.rs
@@ -286,7 +286,7 @@ pub fn watch_serial() -> Result<()> {
                             println!()
                         }
                     } else if endl {
-                        print!("{}: {}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.9f"), c);
+                        print!("{}: {}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f"), c);
                         endl = false;
                     } else {
                         print!("{}", c);

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -286,7 +286,7 @@ pub fn watch_serial() -> Result<()> {
                             println!()
                         }
                     } else if endl {
-                        print!("{}: {}", chrono::Local::now(), c);
+                        print!("{}: {}", chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.9f"), c);
                         endl = false;
                     } else {
                         print!("{}", c);


### PR DESCRIPTION
Updated the time formatting to always display nanoseconds with three digits in the log output

Before
```
2024-05-22 22:52:08.540236200 +08:00: loop...
2024-05-22 22:52:09.539918200 +08:00: loop...
2024-05-22 22:52:09.540122 +08:00: loop...
2024-05-22 22:52:09.540406500 +08:00: loop...
2024-05-22 22:52:09.540730400 +08:00: loop...
```

After
```
2024-05-22 22:52:44.606: loop...
2024-05-22 22:52:44.607: loop...
2024-05-22 22:52:44.607: loop...
2024-05-22 22:52:44.608: loop...
2024-05-22 22:52:45.617: loop...
```

**This is my first time trying a pull request. I'm not sure if I'm doing it right. QAQ**
