### PR TITLE
CH32L103 test OK

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Current firmware version: 2.11 (aka. v31).
 - [ ] [CH643] - I don't have this chip, help wanted
 - [ ] [CH641] - I don't have this chip, help wanted
 - [CH32X035]
-- [ ] [CH32L103] - I don't have this chip, help wanted
+- [CH32L103]
 - [ ] [CH8571] - No other source about this chip, help wanted
 - ... (Feel free to open an issue if you have tested on other chips)
 


### PR DESCRIPTION
I checked that this tool work in CH32L103C8T6 EVT Board.

```
CURRENT: upload_protocol = wlink
Uploading .pio\build\genericCH32L103C8T6\firmware.elf
06:31:39 [INFO] Connected to WCH-Link v2.12(v32) (WCH-LinkE-CH32V305)
06:31:39 [INFO] Attached chip: CH32L103 [CH32L103C8T6] (ChipID: 0x10310710)
06:31:39 [INFO] Chip ESIG: FlashSize(64KB) UID(cd-ab-f0-3b-48-bc-05-a4)
06:31:39 [INFO] Flash protected: false
06:31:39 [INFO] Read .pio\build\genericCH32L103C8T6\firmware.elf as ELF format
06:31:39 [INFO] Flashing 7336 bytes to 0x08000000
06:31:39 [INFO] Read protected: false
06:31:39 [INFO] Flash done
06:31:40 [INFO] Now reset...
```