### PR TITLE
Add 3.3V and 5V output control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Rename ChipUID response to ESignature, #58
+- Add functions to control 3.3V and 5V outputs of probe
 
 ## [0.0.8] - 2024-03-30
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [x] Read chip memory(flash)
 - [x] Read/write chip register - very handy for debugging
 - [x] Code-Protect & Code-Unprotect for supported chips
+- [x] Enable or Disable 3.3V, 5V output
 - [x] [SDI print](https://www.cnblogs.com/liaigu/p/17628184.html) support, requires 2.10+ firmware
 - [x] [Serial port watching](https://github.com/ch32-rs/wlink/pull/36) for a smooth development experience
 - [x] Windows native driver support, no need to install libusb manually (requires x86 build)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Current firmware version: 2.11 (aka. v31).
 - [ ] [CH643] - I don't have this chip, help wanted
 - [ ] [CH641] - I don't have this chip, help wanted
 - [CH32X035]
-- [ ] [CH32L103] - I don't have this chip, help wanted
+- [CH32L103]
 - [ ] [CH8571] - No other source about this chip, help wanted
 - ... (Feel free to open an issue if you have tested on other chips)
 

--- a/src/commands/control.rs
+++ b/src/commands/control.rs
@@ -160,22 +160,26 @@ impl Command for OptEnd {
 }
 
 /// Set Power, from pow3v3, pow5v fn
-#[derive(Debug)]
+#[derive(clap::Subcommand, PartialEq, Clone, Copy, Debug)]
 pub enum SetPower {
-    Enable3V3,
-    Disable3V3,
-    Enable5V,
-    Disable5V,
+    /// Enable 3.3V output
+    Enable3v3,
+    /// Disable 3.3V output
+    Disable3v3,
+    /// Enable 5V output
+    Enable5v,
+    /// Disable 5V output
+    Disable5v,
 }
 impl Command for SetPower {
     type Response = ();
     const COMMAND_ID: u8 = 0x0d;
     fn payload(&self) -> Vec<u8> {
         match self {
-            SetPower::Enable3V3 => vec![0x09],
-            SetPower::Disable3V3 => vec![0x0A],
-            SetPower::Enable5V => vec![0x0B],
-            SetPower::Disable5V => vec![0x0C],
+            SetPower::Enable3v3 => vec![0x09],
+            SetPower::Disable3v3 => vec![0x0A],
+            SetPower::Enable5v => vec![0x0B],
+            SetPower::Disable5v => vec![0x0C],
         }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -425,4 +425,4 @@ impl Command for DisableDebug {
 // 81 0D 01 0F ClearCodeFlashB
 // 81 0D 02 08 xx ClearCodeFlash
 // 81 11 01 0D unknown in query info, before GetChipRomRamSplit
-// 81 0d 02 ee 00 stop flash ?
+// 81 0D 02 EE 00 stop flash ?

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,7 +421,7 @@ fn main() -> Result<()> {
                     sess.dump_info()?;
                     sess.dump_core_csrs()?;
                     sess.dump_dmi()?;
-                }               
+                }
                 Commands::SdiPrint(v) => match v {
                     // By enabling SDI print and modifying the _write function called by printf in the mcu code,
                     // the WCH-Link can be used to read data from the debug interface of the mcu

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,22 @@ fn main() -> Result<()> {
         Some(Commands::List {}) => {
             WchLink::list_probes()?;
         }
+        Some(Commands::Enable3V3 {}) => {
+            log::info!("Enable 3.3V Output");
+            WchLink::set_3v3_output_enabled(true)?;
+        }
+        Some(Commands::Disable3V3 {}) => {
+            log::info!("Disable 3.3V Output");
+            WchLink::set_3v3_output_enabled(false)?;
+        }
+        Some(Commands::Enable5V {}) => {
+            log::info!("Enable 5V Output");
+            WchLink::set_5v_output_enabled(true)?;
+        }
+        Some(Commands::Disable5V {}) => {
+            log::info!("Disable 5V Output");
+            WchLink::set_5v_output_enabled(false)?;
+        }
 
         Some(Commands::Erase { method }) if method != EraseMode::Default => {
             // Special handling for non-default erase: bypass attach chip
@@ -410,22 +426,6 @@ fn main() -> Result<()> {
                     sess.dump_core_csrs()?;
                     sess.dump_dmi()?;
                 }               
-                Commands::Enable3V3 {} => {
-                    log::info!("Enable 3.3V Output");
-                    sess.set_3v3_output_enabled(true)?;
-                }
-                Commands::Disable3V3 {} => {
-                    log::info!("Disable 3.3V Output");
-                    sess.set_3v3_output_enabled(false)?;
-                }
-                Commands::Enable5V {} => {
-                    log::info!("Enable 5V Output");
-                    sess.set_5v_output_enabled(true)?;
-                }
-                Commands::Disable5V {} => {
-                    log::info!("Disable 5V Output");
-                    sess.set_5v_output_enabled(false)?;
-                }
                 Commands::SdiPrint(v) => match v {
                     // By enabling SDI print and modifying the _write function called by printf in the mcu code,
                     // the WCH-Link can be used to read data from the debug interface of the mcu

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,19 +214,19 @@ fn main() -> Result<()> {
         }
         Some(Commands::Enable3V3 {}) => {
             log::info!("Enable 3.3V Output");
-            WchLink::set_3v3_output_enabled(true)?;
+            WchLink::set_3v3_output_enabled(device_index, true)?;
         }
         Some(Commands::Disable3V3 {}) => {
             log::info!("Disable 3.3V Output");
-            WchLink::set_3v3_output_enabled(false)?;
+            WchLink::set_3v3_output_enabled(device_index, false)?;
         }
         Some(Commands::Enable5V {}) => {
             log::info!("Enable 5V Output");
-            WchLink::set_5v_output_enabled(true)?;
+            WchLink::set_5v_output_enabled(device_index, true)?;
         }
         Some(Commands::Disable5V {}) => {
             log::info!("Disable 5V Output");
-            WchLink::set_5v_output_enabled(false)?;
+            WchLink::set_5v_output_enabled(device_index, false)?;
         }
 
         Some(Commands::Erase { method }) if method != EraseMode::Default => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,12 @@ enum Commands {
     },
     /// List probes
     List {},
+    /// Enable 3.3V output
+    Enable3V3 {},
+    /// Disable 3.3V output
+    Disable3V3 {},
+    /// Enable 5V output
+    Enable5V {},
     /// SDI virtual serial port,
     #[command(subcommand)]
     SdiPrint(SdiPrint),
@@ -401,6 +407,22 @@ fn main() -> Result<()> {
                     sess.dump_info()?;
                     sess.dump_core_csrs()?;
                     sess.dump_dmi()?;
+                }               
+                Commands::Enable3V3 {} => {
+                    log::info!("Enable 3.3V Output");
+                    sess.set_3v3_output_enabled(true)?;
+                }
+                Commands::Disable3V3 {} => {
+                    log::info!("Disable 3.3V Output");
+                    sess.set_3v3_output_enabled(false)?;
+                }
+                Commands::Enable5V {} => {
+                    log::info!("Enable 5V Output");
+                    sess.set_5v_output_enabled(true)?;
+                }
+                Commands::Disable5V {} => {
+                    log::info!("Disable 5V Output");
+                    sess.set_5v_output_enabled(false)?;
                 }
                 Commands::SdiPrint(v) => match v {
                     // By enabling SDI print and modifying the _write function called by printf in the mcu code,

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,13 +149,13 @@ enum Commands {
     /// List probes
     List {},
     /// Enable 3.3V output
-    Enable3V3 {},
+    Enable3v3 {},
     /// Disable 3.3V output
-    Disable3V3 {},
+    Disable3v3 {},
     /// Enable 5V output
-    Enable5V {},
+    Enable5v {},
     /// Disable 5V output
-    Disable5V {},
+    Disable5v {},
     /// SDI virtual serial port,
     #[command(subcommand)]
     SdiPrint(SdiPrint),
@@ -212,20 +212,16 @@ fn main() -> Result<()> {
         Some(Commands::List {}) => {
             WchLink::list_probes()?;
         }
-        Some(Commands::Enable3V3 {}) => {
-            log::info!("Enable 3.3V Output");
+        Some(Commands::Enable3v3 {}) => {
             WchLink::set_3v3_output_enabled(device_index, true)?;
         }
-        Some(Commands::Disable3V3 {}) => {
-            log::info!("Disable 3.3V Output");
+        Some(Commands::Disable3v3 {}) => {
             WchLink::set_3v3_output_enabled(device_index, false)?;
         }
-        Some(Commands::Enable5V {}) => {
-            log::info!("Enable 5V Output");
+        Some(Commands::Enable5v {}) => {
             WchLink::set_5v_output_enabled(device_index, true)?;
         }
-        Some(Commands::Disable5V {}) => {
-            log::info!("Disable 5V Output");
+        Some(Commands::Disable5v {}) => {
             WchLink::set_5v_output_enabled(device_index, false)?;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,8 @@ enum Commands {
     Disable3V3 {},
     /// Enable 5V output
     Enable5V {},
+    /// Disable 5V output
+    Disable5V {},
     /// SDI virtual serial port,
     #[command(subcommand)]
     SdiPrint(SdiPrint),

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,14 +148,11 @@ enum Commands {
     },
     /// List probes
     List {},
-    /// Enable 3.3V output
-    Enable3v3 {},
-    /// Disable 3.3V output
-    Disable3v3 {},
-    /// Enable 5V output
-    Enable5v {},
-    /// Disable 5V output
-    Disable5v {},
+    /// Enable or disable power output
+    SetPower {
+        #[command(subcommand)]
+        cmd: commands::control::SetPower,
+    },
     /// SDI virtual serial port,
     #[command(subcommand)]
     SdiPrint(SdiPrint),
@@ -212,17 +209,8 @@ fn main() -> Result<()> {
         Some(Commands::List {}) => {
             WchLink::list_probes()?;
         }
-        Some(Commands::Enable3v3 {}) => {
-            WchLink::set_3v3_output_enabled(device_index, true)?;
-        }
-        Some(Commands::Disable3v3 {}) => {
-            WchLink::set_3v3_output_enabled(device_index, false)?;
-        }
-        Some(Commands::Enable5v {}) => {
-            WchLink::set_5v_output_enabled(device_index, true)?;
-        }
-        Some(Commands::Disable5v {}) => {
-            WchLink::set_5v_output_enabled(device_index, false)?;
+        Some(Commands::SetPower { cmd }) => {
+            WchLink::set_power_output_enabled(device_index, cmd)?;
         }
 
         Some(Commands::Erase { method }) if method != EraseMode::Default => {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -331,42 +331,6 @@ impl ProbeSession {
         Ok(mem)
     }
 
-    pub fn set_3v3_output_enabled(&mut self, enable: bool) -> Result<()> {
-        if !self.probe.info.variant.support_power_funcs() {
-            return Err(Error::Custom(
-                "Probe doesn't support power control".to_string(),
-            ));
-        }
-
-        if enable {
-            self.probe
-                .send_command(commands::control::SetPower::Enable3V3)?;
-        } else {
-            self.probe
-                .send_command(commands::control::SetPower::Disable3V3)?;
-        }
-
-        Ok(())
-    }
-
-    pub fn set_5v_output_enabled(&mut self, enable: bool) -> Result<()> {
-        if !self.probe.info.variant.support_power_funcs() {
-            return Err(Error::Custom(
-                "Probe doesn't support power control".to_string(),
-            ));
-        }
-
-        if enable {
-            self.probe
-                .send_command(commands::control::SetPower::Enable5V)?;
-        } else {
-            self.probe
-                .send_command(commands::control::SetPower::Disable5V)?;
-        }
-
-        Ok(())
-    }
-
     pub fn set_sdi_print_enabled(&mut self, enable: bool) -> Result<()> {
         if !self.probe.info.variant.support_sdi_print() {
             return Err(Error::Custom(

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -339,9 +339,9 @@ impl ProbeSession {
         }
 
         if enable {
-            self.send_command(control::SetPower::Enable3V3)?;
+            self.send_command(commands::control::SetPower::Enable3V3)?;
         } else {
-            self.send_command(control::SetPower::Disable3V3)?;
+            self.send_command(commands::control::SetPower::Disable3V3)?;
         }
 
         Ok(())
@@ -355,9 +355,9 @@ impl ProbeSession {
         }
 
         if enable {
-            self.send_command(control::SetPower::Enable5V)?;
+            self.send_command(commands::control::SetPower::Enable5V)?;
         } else {
-            self.send_command(control::SetPower::Disable5V)?;
+            self.send_command(commands::control::SetPower::Disable5V)?;
         }
 
         Ok(())

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -331,6 +331,38 @@ impl ProbeSession {
         Ok(mem)
     }
 
+    pub fn set_3v3_output_enabled(&mut self, enable: bool) -> Result<()> {
+        if !probe.info.variant.support_power_funcs() {
+            return Err(Error::Custom(
+                "Probe doesn't support power control".to_string(),
+            ));
+        }
+
+        if enable {
+            self.send_command(control::SetPower::Enable3V3)?;
+        } else {
+            self.send_command(control::SetPower::Disable3V3)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn set_5v_output_enabled(&mut self, enable: bool) -> Result<()> {
+        if !probe.info.variant.support_power_funcs() {
+            return Err(Error::Custom(
+                "Probe doesn't support power control".to_string(),
+            ));
+        }
+
+        if enable {
+            self.send_command(control::SetPower::Enable5V)?;
+        } else {
+            self.send_command(control::SetPower::Disable5V)?;
+        }
+
+        Ok(())
+    }
+
     pub fn set_sdi_print_enabled(&mut self, enable: bool) -> Result<()> {
         if !self.probe.info.variant.support_sdi_print() {
             return Err(Error::Custom(

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -332,7 +332,7 @@ impl ProbeSession {
     }
 
     pub fn set_3v3_output_enabled(&mut self, enable: bool) -> Result<()> {
-        if !probe.info.variant.support_power_funcs() {
+        if !self.probe.info.variant.support_power_funcs() {
             return Err(Error::Custom(
                 "Probe doesn't support power control".to_string(),
             ));
@@ -348,7 +348,7 @@ impl ProbeSession {
     }
 
     pub fn set_5v_output_enabled(&mut self, enable: bool) -> Result<()> {
-        if !probe.info.variant.support_power_funcs() {
+        if !self.probe.info.variant.support_power_funcs() {
             return Err(Error::Custom(
                 "Probe doesn't support power control".to_string(),
             ));

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -339,9 +339,11 @@ impl ProbeSession {
         }
 
         if enable {
-            self.send_command(commands::control::SetPower::Enable3V3)?;
+            self.probe
+                .send_command(commands::control::SetPower::Enable3V3)?;
         } else {
-            self.send_command(commands::control::SetPower::Disable3V3)?;
+            self.probe
+                .send_command(commands::control::SetPower::Disable3V3)?;
         }
 
         Ok(())
@@ -355,9 +357,11 @@ impl ProbeSession {
         }
 
         if enable {
-            self.send_command(commands::control::SetPower::Enable5V)?;
+            self.probe
+                .send_command(commands::control::SetPower::Enable5V)?;
         } else {
-            self.send_command(commands::control::SetPower::Disable5V)?;
+            self.probe
+                .send_command(commands::control::SetPower::Disable5V)?;
         }
 
         Ok(())

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -173,6 +173,42 @@ impl WchLink {
         Ok(())
     }
 
+    pub fn set_3v3_output_enabled(&mut self, enable: bool) -> Result<()> {
+        if !self.probe.info.variant.support_power_funcs() {
+            return Err(Error::Custom(
+                "Probe doesn't support power control".to_string(),
+            ));
+        }
+
+        if enable {
+            self.probe
+                .send_command(commands::control::SetPower::Enable3V3)?;
+        } else {
+            self.probe
+                .send_command(commands::control::SetPower::Disable3V3)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn set_5v_output_enabled(&mut self, enable: bool) -> Result<()> {
+        if !self.probe.info.variant.support_power_funcs() {
+            return Err(Error::Custom(
+                "Probe doesn't support power control".to_string(),
+            ));
+        }
+
+        if enable {
+            self.probe
+                .send_command(commands::control::SetPower::Enable5V)?;
+        } else {
+            self.probe
+                .send_command(commands::control::SetPower::Disable5V)?;
+        }
+
+        Ok(())
+    }
+
     fn write_raw_cmd(&mut self, buf: &[u8]) -> Result<()> {
         log::trace!("send {} {}", hex::encode(&buf[..3]), hex::encode(&buf[3..]));
         self.device.write_endpoint(ENDPOINT_OUT, buf)?;

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -183,8 +183,10 @@ impl WchLink {
         }
 
         if enable {
+            log::info!("Enable 3.3V Output");
             probe.send_command(commands::control::SetPower::Enable3V3)?;
         } else {
+            log::info!("Disable 3.3V Output");
             probe.send_command(commands::control::SetPower::Disable3V3)?;
         }
 
@@ -201,8 +203,10 @@ impl WchLink {
         }
 
         if enable {
+            log::info!("Enable 5V Output");
             probe.send_command(commands::control::SetPower::Enable5V)?;
         } else {
+            log::info!("Disable 5V Output");
             probe.send_command(commands::control::SetPower::Disable5V)?;
         }
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -173,37 +173,37 @@ impl WchLink {
         Ok(())
     }
 
-    pub fn set_3v3_output_enabled(&mut self, enable: bool) -> Result<()> {
-        if !self.probe.info.variant.support_power_funcs() {
+    pub fn set_3v3_output_enabled(nth: usize, enable: bool) -> Result<()> {
+        let mut probe = Self::open_nth(nth)?;
+
+        if !probe.info.variant.support_power_funcs() {
             return Err(Error::Custom(
                 "Probe doesn't support power control".to_string(),
             ));
         }
 
         if enable {
-            self.probe
-                .send_command(commands::control::SetPower::Enable3V3)?;
+            probe.send_command(commands::control::SetPower::Enable3V3)?;
         } else {
-            self.probe
-                .send_command(commands::control::SetPower::Disable3V3)?;
+            probe.send_command(commands::control::SetPower::Disable3V3)?;
         }
 
         Ok(())
     }
 
-    pub fn set_5v_output_enabled(&mut self, enable: bool) -> Result<()> {
-        if !self.probe.info.variant.support_power_funcs() {
+    pub fn set_5v_output_enabled(nth: usize, enable: bool) -> Result<()> {
+        let mut probe = Self::open_nth(nth)?;
+
+        if !probe.info.variant.support_power_funcs() {
             return Err(Error::Custom(
                 "Probe doesn't support power control".to_string(),
             ));
         }
 
         if enable {
-            self.probe
-                .send_command(commands::control::SetPower::Enable5V)?;
+            probe.send_command(commands::control::SetPower::Enable5V)?;
         } else {
-            self.probe
-                .send_command(commands::control::SetPower::Disable5V)?;
+            probe.send_command(commands::control::SetPower::Disable5V)?;
         }
 
         Ok(())

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -173,7 +173,7 @@ impl WchLink {
         Ok(())
     }
 
-    pub fn set_3v3_output_enabled(nth: usize, enable: bool) -> Result<()> {
+    pub fn set_power_output_enabled(nth: usize, cmd: commands::control::SetPower) -> Result<()> {
         let mut probe = Self::open_nth(nth)?;
 
         if !probe.info.variant.support_power_funcs() {
@@ -182,32 +182,13 @@ impl WchLink {
             ));
         }
 
-        if enable {
-            log::info!("Enable 3.3V Output");
-            probe.send_command(commands::control::SetPower::Enable3V3)?;
-        } else {
-            log::info!("Disable 3.3V Output");
-            probe.send_command(commands::control::SetPower::Disable3V3)?;
-        }
+        probe.send_command(cmd)?;
 
-        Ok(())
-    }
-
-    pub fn set_5v_output_enabled(nth: usize, enable: bool) -> Result<()> {
-        let mut probe = Self::open_nth(nth)?;
-
-        if !probe.info.variant.support_power_funcs() {
-            return Err(Error::Custom(
-                "Probe doesn't support power control".to_string(),
-            ));
-        }
-
-        if enable {
-            log::info!("Enable 5V Output");
-            probe.send_command(commands::control::SetPower::Enable5V)?;
-        } else {
-            log::info!("Disable 5V Output");
-            probe.send_command(commands::control::SetPower::Disable5V)?;
+        match cmd {
+            commands::control::SetPower::Enable3v3 => log::info!("Enable 3.3V Output"),
+            commands::control::SetPower::Disable3v3 => log::info!("Disable 3.3V Output"),
+            commands::control::SetPower::Enable5v => log::info!("Enable 5V Output"),
+            commands::control::SetPower::Disable5v => log::info!("Disable 5V Output"),
         }
 
         Ok(())


### PR DESCRIPTION
I added these commands, and already tested on WCH-LinkE.
```
> wlink set-power --help 
Enable or disable power output

Usage: wlink set-power [OPTIONS] <COMMAND>

Commands:
  enable3v3   Enable 3.3V output
  disable3v3  Disable 3.3V output
  enable5v    Enable 5V output
  disable5v   Disable 5V output
  help        Print this message or the help of the given subcommand(s)
```

example
```
> wlink set-power enable3v3
13:31:46 [INFO] Connected to WCH-Link v2.12(v32) (WCH-LinkE-CH32V305)
13:31:46 [INFO] Enable 3.3V Output

> wlink set-power disable3v3
13:31:52 [INFO] Connected to WCH-Link v2.12(v32) (WCH-LinkE-CH32V305)
13:31:52 [INFO] Disable 3.3V Output

> wlink set-power enable5v
13:32:03 [INFO] Connected to WCH-Link v2.12(v32) (WCH-LinkE-CH32V305)
13:32:03 [INFO] Enable 5V Output

> wlink set-power disable5v
13:32:07 [INFO] Connected to WCH-Link v2.12(v32) (WCH-LinkE-CH32V305)
13:32:07 [INFO] Disable 5V Output
```

When merge this PR, I recommend that squash and merge.