### PR TITLE
Fix: special elf program header with zero p_filesz

### DIFF
--- a/src/firmware.rs
+++ b/src/firmware.rs
@@ -196,6 +196,11 @@ pub fn read_elf(elf_data: &[u8]) -> Result<Firmware> {
 
         let flags = segment.p_flags(endian);
 
+        // The number of bytes in the file image of the segment, which can be zero.
+        if segment.p_filesz(endian) == 0 {
+            // skip empty segment
+            continue;
+        }
         let segment_data = segment
             .data(endian, elf_data)
             .map_err(|_| anyhow::format_err!("Failed to access data for an ELF segment."))?;


### PR DESCRIPTION
Fix #77

This might also affect [probe-rs](https://github.com/probe-rs/probe-rs).

The original defect is that the `object` crate returns an Error accessing `data` when `p_filesz` of a `ProgramHeader` is zero. (I belive it should return an empty slice).

In case #77: the second ProgramHeader's `p_filesz` is zero.

```
firmware.elf:     file format elf32-littleriscv

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .init         00000004  00000000  00000000  00001000  2**1
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .vector       00000004  00000004  00000004  00001004  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  2 .text         000001e4  00000008  00000008  00001008  2**1
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  3 .fini         00000000  000001ec  000001ec  000011ec  2**0
                  CONTENTS, ALLOC, LOAD, CODE

=> The above sections belong to the first ProgramHeader.
  p_vaddr: U32(0), p_paddr: U32(0), p_filesz: U32(1ec), p_memsz: U32(1ec)
=> The following sections belong to the second ProgramHeader.
  p_vaddr: U32(20000000), p_paddr: U32(1ec), p_filesz: U32(0), p_memsz: U32(4)

  4 .dalign       00000000  20000000  20000000  000011ec  2**0
                  CONTENTS
  5 .dlalign      00000000  000001ec  000001ec  000011ec  2**0
                  CONTENTS
  6 .data         00000000  20000000  20000000  000011ec  2**0
                  CONTENTS, ALLOC, LOAD, DATA
  7 .bss          00000004  20000000  000001ec  00002000  2**2
                  ALLOC
  8 .comment      00000033  00000000  00000000  000011ec  2**0
                  CONTENTS, READONLY
```

CC @maxgerhardt