### PR TITLE
add serialnumber to ./wlink list command output

### DIFF
--- a/src/usb_device.rs
+++ b/src/usb_device.rs
@@ -65,13 +65,16 @@ pub mod libusb {
         for device in devices.iter() {
             let device_desc = device.device_descriptor()?;
             if device_desc.vendor_id() == vid && device_desc.product_id() == pid {
+                let handle = device.open()?;
+                let serialnumber = handle.read_serial_number_string_ascii(&device_desc)?;
                 result.push(format!(
-                    "<WCH-Link#{} libusb device> Bus {:03} Device {:03} ID {:04x}:{:04x}({})",
+                    "<WCH-Link#{} libusb device> Bus {:03} Device {:03} ID {:04x}:{:04x} Serial {} ({})",
                     idx,
                     device.bus_number(),
                     device.address(),
                     device_desc.vendor_id(),
                     device_desc.product_id(),
+                    serialnumber,
                     get_speed(device.speed())
                 ));
                 idx += 1;

--- a/src/usb_device.rs
+++ b/src/usb_device.rs
@@ -65,8 +65,11 @@ pub mod libusb {
         for device in devices.iter() {
             let device_desc = device.device_descriptor()?;
             if device_desc.vendor_id() == vid && device_desc.product_id() == pid {
-                let handle = device.open()?;
-                let serialnumber = handle.read_serial_number_string_ascii(&device_desc)?;
+                let serialnumber = match device.open() {
+                    Ok(handle) => handle.read_serial_number_string_ascii(&device_desc)
+                        .unwrap_or_else(|_| String::from("N/A")),
+                    Err(_) => String::from("N/A"),
+                };
                 result.push(format!(
                     "<WCH-Link#{} libusb device> Bus {:03} Device {:03} ID {:04x}:{:04x} Serial {} ({})",
                     idx,


### PR DESCRIPTION
Add the programmer's USB serial number to the ./wlink list command output. This becomes handy when having more than one programmer connected at the same time.
At least on Windows, Bus and Device number cannot be used to identify a programmer. The device number changes with every reconnect of the programmer.

Only works with libusb.
