### PR TITLE
feat: include USB serial number in probe listing

### DIFF
--- a/src/usb_device.rs
+++ b/src/usb_device.rs
@@ -65,11 +65,17 @@ pub mod libusb {
 
         for device in devices {
             if device.vendor_id() == vid && device.product_id() == pid {
+                let serial = device
+                    .serial_number()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "N/A".to_string());
+
                 result.push(format!(
-                    "<WCH-Link#{} nusb device> ID {:04x}:{:04x}({})",
+                    "<WCH-Link#{} nusb device> ID {:04x}:{:04x} Serial {} ({})",
                     idx,
                     device.vendor_id(),
                     device.product_id(),
+                    serial,
                     get_speed(device.speed())
                 ));
                 idx += 1;


### PR DESCRIPTION
Adds USB serial number to `wlink list` output for multi-probe identification.

Based on the original work by @mon7gomery in #91, but rewritten to use the current nusb API (migration from rusb happened in #97).

## Changes
- Uses `device.serial_number()` from nusb DeviceInfo
- Graceful fallback to "N/A" if serial unavailable  
- Output format: `<WCH-Link#N nusb device> ID xxxx:xxxx Serial <number> (speed)`

## Testing
- ✅ `cargo build` passes
- ✅ `cargo test` passes

Closes #91

Co-authored-by: Marcel Kraft <marcel@luke-roberts.com>