### PR TITLE
ci: enable only-when-changed for nightly release (fixes #92)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
           name: "wlink nightly release $$"
           draft: false
           prerelease: true
+          # Skip republishing when the nightly tag is already at HEAD — avoids
+          # spamming watchers with empty re-releases on cron runs (issue #92).
+          only-when-changed: true
           body: |
             This is a nightly binary release of the wlink command line tool.
 


### PR DESCRIPTION
## Summary

- Set `only-when-changed: true` on the `andelf/nightly-release@main` step in `ci.yml` so the cron-triggered nightly job no longer republishes the release when nothing has changed since the previous run.
- Adds an inline comment pointing back to issue #92 so future readers see why the flag is here.

## Context

The cron at `0 14 * * *` rebuilds + republishes nightly every day. Without this flag, even runs where `HEAD == refs/tags/nightly` would still:
- delete every existing release asset
- re-upload them
- bump the release `updated_at`

…which surfaces in watchers' dashboards as a fresh release notification, which is the user complaint in #92.

`andelf/nightly-release` recently grew an `only-when-changed` input ([andelf/nightly-release@5834076](https://github.com/andelf/nightly-release/commit/5834076edc55cc05975561c9722043f072ac5c26), default `true`) that early-returns when the existing nightly tag ref already points at `GITHUB_SHA`. Since wlink pins `@main`, the new default is already in effect — this PR just makes the opt-in explicit at the call site so the behavior is visible in the workflow file.

## Verification

End-to-end behavior was verified upstream by re-running the action's own `build-test` workflow on the same commit twice. Second run logged:

> `🛑 nightly already at <sha>, skipping (only-when-changed=true)`

…and the existing release's `createdAt` / `updatedAt` / asset timestamps were untouched. Build matrix (windows-x64/x86, linux-x64, macos-arm64) is unaffected — only the final "Update Nightly Release" step early-exits.

## Test plan

- [x] CI passes on this PR
- [ ] After merge, observe next cron tick (14:00 UTC). If main is unchanged since the previous nightly tag SHA, the action logs `🛑 nightly already at <sha>, skipping` and the release in the GitHub UI keeps its prior `updated_at`.
- [ ] If main has new commits, the action runs normally — assets are refreshed and watchers are notified (the wanted case).

Fixes #92