### PR TITLE
fix: Flash and Erase command  clobbers Option Bytes unconditionally

### DIFF
--- a/src/operations.rs
+++ b/src/operations.rs
@@ -133,20 +133,18 @@ impl ProbeSession {
         // HACK: requires a fresh attach
         self.reattach_chip()?;
 
-        let read_protected = self
+        let mut read_protected = self
             .probe
             .send_command(commands::ConfigChip::CheckReadProtect)?;
+        // Skip Unprotect when not protected: the probe firmware mass-erases
+        // the option-byte page, wiping USER/Data/WRPR.
         if read_protected == commands::ConfigChip::FLAG_READ_PROTECTED {
-            log::info!("Flash already unprotected");
+            self.probe.send_command(commands::ConfigChip::Unprotect)?;
+            self.reattach_chip()?;
+            read_protected = self
+                .probe
+                .send_command(commands::ConfigChip::CheckReadProtect)?;
         }
-
-        self.probe.send_command(commands::ConfigChip::Unprotect)?;
-
-        self.reattach_chip()?;
-
-        let read_protected = self
-            .probe
-            .send_command(commands::ConfigChip::CheckReadProtect)?;
         log::info!(
             "Read protected: {}",
             read_protected == commands::ConfigChip::FLAG_READ_PROTECTED
@@ -212,9 +210,7 @@ impl ProbeSession {
             if ret == commands::ConfigChip::FLAG_READ_PROTECTED {
                 log::warn!("Flash is protected, unprotecting...");
                 self.unprotect_flash()?;
-            } else if ret == 2 {
-                self.unprotect_flash()?; // FIXME: 2 is unknown
-            } else {
+            } else if ret != 2 {
                 log::warn!("Unknown flash protect status: {}", ret);
             }
         }


### PR DESCRIPTION
## Problem

Current implementation unconditionally calls `Unprotect` and thus reset the entire Option Bytes data.

## Solution

This PR gates `Unprotect` on `CheckReadProtect == FLAG_READ_PROTECTED` and drops the spurious call from erase_flash. Also fixes an inverted "Flash already unprotected" log on the protected branch.

## Verification

Verified locally on a CH32V006 chip. Both flash and erase commands now skips Option Byte reset if it's not protected.