### PR TITLE
Preserve write-protect handling during erase

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -184,7 +184,9 @@ pub enum ConfigChip {
 }
 impl ConfigChip {
     pub const FLAG_READ_PROTECTED: u8 = 0x01;
+    pub const FLAG_READ_UNPROTECTED: u8 = 0x02;
     pub const FLAG_WRITE_PROTECTED: u8 = 0x11;
+    pub const FLAG_WRITE_UNPROTECTED: u8 = 0x00;
 }
 impl Command for ConfigChip {
     type Response = u8;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -213,7 +213,17 @@ impl ProbeSession {
             if ret == commands::ConfigChip::FLAG_READ_PROTECTED {
                 log::warn!("Flash is protected, unprotecting...");
                 self.unprotect_flash()?;
-            } else if ret != 2 {
+            } else if ret == commands::ConfigChip::FLAG_READ_UNPROTECTED {
+                let write_protected = self
+                    .probe
+                    .send_command(commands::ConfigChip::CheckReadProtectEx)?;
+                if write_protected == commands::ConfigChip::FLAG_WRITE_PROTECTED {
+                    log::warn!("Flash is write protected, unprotecting...");
+                    self.unprotect_flash()?;
+                } else if write_protected != commands::ConfigChip::FLAG_WRITE_UNPROTECTED {
+                    log::warn!("Unknown flash write protect status: {}", write_protected);
+                }
+            } else {
                 log::warn!("Unknown flash protect status: {}", ret);
             }
         }


### PR DESCRIPTION
Follow-up to #108.

#108 avoids sending ConfigChip::Unprotect when read protection is already disabled, preserving Option Bytes. This keeps the erase path from losing the existing write-protect cleanup: when CheckReadProtect returns the read-unprotected value, erase still checks CheckReadProtectEx and only calls unprotect_flash when WRP is actually active.

Verification:
- cargo test --all-targets
- cargo fmt --check