### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-05-01
+
 ### Added
 
 - Add experimental CH32H41x support, including CH32H417 flashing, package ID reporting, and CH32H415/CH32H416/CH32H417 chip aliases.
+- Include USB serial numbers in probe listing output.
 
 ### Changed
 
 - Migrate from rusb to nusb 0.2
+- Rename the CH32V007 chip family to CH32V00X.
 
 ### Fixed
 
 - Fix compile error on Windows
 - Fix CH585 incorrectly reporting itself as CH59x
+- Preserve the original attach error details when chip attach fails.
+- Preserve option bytes by skipping read-unprotect when flash is already read-unprotected.
+- Preserve write-protect cleanup during erase after skipping unnecessary read-unprotect.
 
 ## [0.1.1] - 2024-11-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wlink"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wlink"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Andelf <andelf@gmail.com>"]
 repository = "https://github.com/ch32-rs/wlink"


### PR DESCRIPTION
Prepare wlink v0.1.2 release.

Changes:
- Move current changelog entries into `0.1.2` dated 2026-05-01.
- Add missing changelog entries for USB serial listing, CH32V00X rename, attach error preservation, option byte preservation, and erase WRP cleanup.
- Bump crate version to `0.1.2`.

Verification:
- cargo fmt --check
- cargo test --all-targets
- cargo publish --dry-run