### PR TITLE
Read or set MCU SRAM_CODE_MODE

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -110,10 +110,10 @@ oOp_u8 = 0x02 when failed
 - 0x02 Connect chip
 - 0x03 ? stage after connect chip and read riscvchip, for riscvchip 1
 - 0x04 get rom ram split, for riscvchip 3, 5, 6, 9
-- 0x17 Get MCU Memory Assign (SRAM_CODE_MODE)
+- 0x17 Get MCU Memory Split (SRAM_CODE_MODE)
   - Request: `81 0d 01 17`
   - Response payload: one byte mode value
-- 0x18 Set MCU Memory Assign (SRAM_CODE_MODE)
+- 0x18 Set MCU Memory Split (SRAM_CODE_MODE)
   - Request: `81 0d 02 18 <mode>`
   - Response payload: `18` (ACK)
 - 0xff End process

--- a/protocol.md
+++ b/protocol.md
@@ -110,7 +110,30 @@ oOp_u8 = 0x02 when failed
 - 0x02 Connect chip
 - 0x03 ? stage after connect chip and read riscvchip, for riscvchip 1
 - 0x04 get rom ram split, for riscvchip 3, 5, 6, 9
+- 0x17 Get MCU Memory Assign (SRAM_CODE_MODE)
+  - Request: `81 0d 01 17`
+  - Response payload: one byte mode value
+- 0x18 Set MCU Memory Assign (SRAM_CODE_MODE)
+  - Request: `81 0d 02 18 <mode>`
+  - Response payload: `18` (ACK)
 - 0xff End process
+
+#### SRAM_CODE_MODE mapping (CH32V2x/V3x USER[7:5])
+
+Based on CH32FV2x_V3xRM and USB captures from WCH official tool.
+
+- `00x` (`0x00` or `0x01`) -> CODE-192KB + RAM-128KB
+- `01x` (`0x02` or `0x03`) -> CODE-224KB + RAM-96KB
+- `10x` (`0x04` or `0x05`) -> CODE-256KB + RAM-64KB
+- `110` (`0x06`) -> CODE-128KB + RAM-192KB
+- `111` (`0x07`) -> CODE-288KB + RAM-32KB
+
+Observed set/read pairs in captures (verified on CH32V30X):
+
+- set `0x18 0x01` -> read `0x17` returns `0x01` (192/128)
+- set `0x18 0x03` -> read `0x17` returns `0x03` (224/96)
+- set `0x18 0x05` -> read `0x17` returns `0x05` (256/64)
+- set `0x18 0x07` -> read `0x17` returns `0x07` (288/32)
 
 ### 0x0e
 

--- a/src/commands/control.rs
+++ b/src/commands/control.rs
@@ -135,12 +135,12 @@ impl Command for GetChipRomRamSplit {
     }
 }
 
-/// Get MCU Memory Assign (SRAM_CODE_MODE)
+/// Get MCU Memory Split (SRAM_CODE_MODE)
 /// Observed in official tool as command sequence: 81 0d 01 17
 /// Response payload is one byte mode value (USER[7:5]-related).
 #[derive(Debug)]
-pub struct GetMcuMemoryAssign;
-impl Command for GetMcuMemoryAssign {
+pub struct GetMcuMemorySplit;
+impl Command for GetMcuMemorySplit {
     type Response = u8;
     const COMMAND_ID: u8 = 0x0d;
     fn payload(&self) -> Vec<u8> {
@@ -150,7 +150,7 @@ impl Command for GetMcuMemoryAssign {
 
 /// 0, 1, 2, 3
 #[derive(Debug)]
-pub struct SetChipRomRamSplit(u8);
+pub struct SetChipRomRamSplit(pub u8);
 impl Command for SetChipRomRamSplit {
     type Response = ();
     const COMMAND_ID: u8 = 0x0d;
@@ -159,12 +159,12 @@ impl Command for SetChipRomRamSplit {
     }
 }
 
-/// Set MCU Memory Assign (SRAM_CODE_MODE)
+/// Set MCU Memory Split (SRAM_CODE_MODE)
 /// Observed in official tool as command sequence: 81 0d 02 18 <mode>
 /// Response payload is one byte: 0x18 (subcommand echo/ack).
 #[derive(Debug)]
-pub struct SetMcuMemoryAssign(pub u8);
-impl Command for SetMcuMemoryAssign {
+pub struct SetMcuMemorySplit(pub u8);
+impl Command for SetMcuMemorySplit {
     type Response = u8;
     const COMMAND_ID: u8 = 0x0d;
     fn payload(&self) -> Vec<u8> {

--- a/src/commands/control.rs
+++ b/src/commands/control.rs
@@ -135,6 +135,19 @@ impl Command for GetChipRomRamSplit {
     }
 }
 
+/// Get MCU Memory Assign (SRAM_CODE_MODE)
+/// Observed in official tool as command sequence: 81 0d 01 17
+/// Response payload is one byte mode value (USER[7:5]-related).
+#[derive(Debug)]
+pub struct GetMcuMemoryAssign;
+impl Command for GetMcuMemoryAssign {
+    type Response = u8;
+    const COMMAND_ID: u8 = 0x0d;
+    fn payload(&self) -> Vec<u8> {
+        vec![0x17]
+    }
+}
+
 /// 0, 1, 2, 3
 #[derive(Debug)]
 pub struct SetChipRomRamSplit(u8);
@@ -143,6 +156,19 @@ impl Command for SetChipRomRamSplit {
     const COMMAND_ID: u8 = 0x0d;
     fn payload(&self) -> Vec<u8> {
         vec![0x05, self.0]
+    }
+}
+
+/// Set MCU Memory Assign (SRAM_CODE_MODE)
+/// Observed in official tool as command sequence: 81 0d 02 18 <mode>
+/// Response payload is one byte: 0x18 (subcommand echo/ack).
+#[derive(Debug)]
+pub struct SetMcuMemoryAssign(pub u8);
+impl Command for SetMcuMemoryAssign {
+    type Response = u8;
+    const COMMAND_ID: u8 = 0x0d;
+    fn payload(&self) -> Vec<u8> {
+        vec![0x18, self.0]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,12 @@ impl RiscvChip {
         )
     }
 
+    /// Support observed MCU Memory Assign commands (0x0d/0x17, 0x0d/0x18)
+    /// based on verified CH32V30X captures.
+    pub(crate) fn support_mcu_memory_assign_cmds(&self) -> bool {
+        matches!(self, RiscvChip::CH32V30X)
+    }
+
     /// Support config registers, query info(UID, etc.)
     pub fn support_query_info(&self) -> bool {
         !matches!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,10 +209,16 @@ impl RiscvChip {
         )
     }
 
-    /// Support observed MCU Memory Assign commands (0x0d/0x17, 0x0d/0x18)
+    /// Support observed MCU Memory Split commands (0x0d/0x17, 0x0d/0x18)
     /// based on verified CH32V30X captures.
-    pub(crate) fn support_mcu_memory_assign_cmds(&self) -> bool {
+    pub(crate) fn support_mcu_mem_split_cmds(&self) -> bool {
         matches!(self, RiscvChip::CH32V30X)
+    }
+
+    /// Support legacy RAM/ROM split commands (0x0d/0x04, 0x0d/0x05)
+    /// used for CH32V20X memory split configuration.
+    pub(crate) fn support_mcu_mem_split_legacy_cmds(&self) -> bool {
+        matches!(self, RiscvChip::CH32V20X)
     }
 
     /// Support config registers, query info(UID, etc.)

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,14 @@ enum Commands {
     /// SDI virtual serial port,
     #[command(subcommand)]
     SdiPrint(SdiPrint),
+    #[command(
+        after_help = "Quick mode map:\n  192-128 => 0x01 (also 0x00)\n  224-96  => 0x03 (also 0x02)\n  256-64  => 0x05 (also 0x04)\n  128-192 => 0x06\n  288-32  => 0x07\n\nFor full details run: wlink help memory-assign set"
+    )]
+    /// Read or set MCU Memory Assign (SRAM_CODE_MODE)
+    MemoryAssign {
+        #[command(subcommand)]
+        cmd: MemoryAssign,
+    },
     Dev {},
 }
 
@@ -171,6 +179,61 @@ impl SdiPrint {
     pub fn is_enable(&self) -> bool {
         *self == SdiPrint::Enable
     }
+}
+
+#[derive(clap::Subcommand, PartialEq, Clone, Copy, Debug)]
+pub enum MemoryAssign {
+    /// Read current SRAM_CODE_MODE
+    Get,
+    /// Set SRAM_CODE_MODE using hex value or compact profile alias
+    Set {
+        ///
+        /// Accepted values:
+        /// - 192-128 => 0x01 (also accepts 0x00)
+        /// - 224-96  => 0x03 (also accepts 0x02)
+        /// - 256-64  => 0x05 (also accepts 0x04)
+        /// - 128-192 => 0x06
+        /// - 288-32  => 0x07
+        ///
+        /// Also accepted aliases:
+        /// - 192, 224, 256, 128, 288
+        /// - p0, p1, p2, p3, p4
+        #[arg(
+            value_parser = parse_memory_assign_mode,
+            value_name = "MODE",
+            long_help = "SRAM_CODE_MODE value.\n\nAccepted formats:\n  - Hex/raw: 0x00..0x07\n  - Profile aliases: 192-128, 224-96, 256-64, 128-192, 288-32\n  - Compact aliases: 192, 224, 256, 128, 288, p0..p4\n\nProfile to hex mapping:\n  - 192-128 => 0x01 (also 0x00)\n  - 224-96  => 0x03 (also 0x02)\n  - 256-64  => 0x05 (also 0x04)\n  - 128-192 => 0x06\n  - 288-32  => 0x07"
+        )]
+        mode: u8,
+        /// Skip read-back verify after write
+        #[arg(long, default_value = "false")]
+        no_verify: bool,
+    },
+}
+
+fn decode_mcu_memory_assign_mode(mode: u8) -> &'static str {
+    match mode & 0x07 {
+        0b000 | 0b001 => "CODE-192KB + RAM-128KB",
+        0b010 | 0b011 => "CODE-224KB + RAM-96KB",
+        0b100 | 0b101 => "CODE-256KB + RAM-64KB",
+        0b110 => "CODE-128KB + RAM-192KB",
+        0b111 => "CODE-288KB + RAM-32KB",
+        _ => "UNKNOWN",
+    }
+}
+
+fn mcu_memory_assign_profile_id(mode: u8) -> u8 {
+    match mode & 0x07 {
+        0b000 | 0b001 => 0,
+        0b010 | 0b011 => 1,
+        0b100 | 0b101 => 2,
+        0b110 => 3,
+        0b111 => 4,
+        _ => 0xff,
+    }
+}
+
+fn is_same_mcu_memory_assign_profile(expected: u8, observed: u8) -> bool {
+    mcu_memory_assign_profile_id(expected) == mcu_memory_assign_profile_id(observed)
 }
 
 fn main() -> Result<()> {
@@ -427,6 +490,39 @@ fn main() -> Result<()> {
                         sess.set_sdi_print_enabled(false)?;
                     }
                 },
+                Commands::MemoryAssign { cmd } => match cmd {
+                    MemoryAssign::Get => {
+                        let mode = sess.get_mcu_memory_assign()?;
+                        let profile = decode_mcu_memory_assign_mode(mode);
+                        log::info!(
+                            "MCU Memory Assign: 0x{:02x} ({})",
+                            mode,
+                            profile
+                        );
+                        println!("0x{mode:02x} ({profile})");
+                    }
+                    MemoryAssign::Set { mode, no_verify } => {
+                        let profile = decode_mcu_memory_assign_mode(mode);
+                        log::info!("Set MCU Memory Assign to 0x{:02x} ({})", mode, profile);
+                        sess.set_mcu_memory_assign(mode)?;
+
+                        if !no_verify {
+                            let read_back = sess.get_mcu_memory_assign()?;
+                            let read_profile = decode_mcu_memory_assign_mode(read_back);
+                            if !is_same_mcu_memory_assign_profile(mode, read_back) {
+                                return Err(wlink::Error::Custom(format!(
+                                    "MCU Memory Assign verify failed: wrote 0x{mode:02x} ({profile}), read back 0x{read_back:02x} ({read_profile})"
+                                ))
+                                .into());
+                            }
+                            log::info!(
+                                "MCU Memory Assign verified: 0x{:02x} ({})",
+                                read_back,
+                                read_profile
+                            );
+                        }
+                    }
+                },
                 _ => unreachable!("unimplemented command"),
             }
             if will_detach {
@@ -450,4 +546,30 @@ pub fn parse_number(s: &str) -> std::result::Result<u32, String> {
     } else {
         Ok(s.parse().expect("must be a number"))
     }
+}
+
+pub fn parse_memory_assign_mode(s: &str) -> std::result::Result<u8, String> {
+    let norm = s.trim().to_lowercase().replace('_', "-");
+
+    let canonical = match norm.as_str() {
+        // profile aliases (CODE-RAM)
+        "192-128" | "192/128" | "192:128" | "192" | "p0" => Some(0x01),
+        "224-96" | "224/96" | "224:96" | "224" | "p1" => Some(0x03),
+        "256-64" | "256/64" | "256:64" | "256" | "p2" => Some(0x05),
+        "128-192" | "128/192" | "128:192" | "128" | "p3" => Some(0x06),
+        "288-32" | "288/32" | "288:32" | "288" | "p4" => Some(0x07),
+        _ => None,
+    };
+
+    if let Some(mode) = canonical {
+        return Ok(mode);
+    }
+
+    let raw = parse_number(s)?;
+    let raw = u8::try_from(raw).map_err(|_| "mode must be in range 0x00..0x07".to_string())?;
+    if raw > 0x07 {
+        return Err("mode must be in range 0x00..0x07".to_string());
+    }
+
+    Ok(raw)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,12 +157,12 @@ enum Commands {
     #[command(subcommand)]
     SdiPrint(SdiPrint),
     #[command(
-        after_help = "Quick mode map:\n  192-128 => 0x01 (also 0x00)\n  224-96  => 0x03 (also 0x02)\n  256-64  => 0x05 (also 0x04)\n  128-192 => 0x06\n  288-32  => 0x07\n\nFor full details run: wlink help memory-assign set"
+        after_help = "Quick mode map:\n  CH32V30X:\n    192-128 => 0x01 (also 0x00)\n    224-96  => 0x03 (also 0x02)\n    256-64  => 0x05 (also 0x04)\n    128-192 => 0x06\n    288-32  => 0x07\n\n  CH32V20X:\n    128-64  => 0x00 (also 0x01 by bit-pattern)\n    144-48  => 0x02 (also 0x03 by bit-pattern)\n    160-32  => 0x04..0x07 (legacy index commonly 0x02)\n\nFor full details run: wlink help mem-split set"
     )]
-    /// Read or set MCU Memory Assign (SRAM_CODE_MODE)
-    MemoryAssign {
+    /// Read or set MCU Memory Split (SRAM_CODE_MODE)
+    MemSplit {
         #[command(subcommand)]
-        cmd: MemoryAssign,
+        cmd: MemSplit,
     },
     Dev {},
 }
@@ -181,36 +181,30 @@ impl SdiPrint {
     }
 }
 
-#[derive(clap::Subcommand, PartialEq, Clone, Copy, Debug)]
-pub enum MemoryAssign {
+#[derive(clap::Subcommand, PartialEq, Clone, Debug)]
+pub enum MemSplit {
     /// Read current SRAM_CODE_MODE
     Get,
     /// Set SRAM_CODE_MODE using hex value or compact profile alias
     Set {
         ///
-        /// Accepted values:
-        /// - 192-128 => 0x01 (also accepts 0x00)
-        /// - 224-96  => 0x03 (also accepts 0x02)
-        /// - 256-64  => 0x05 (also accepts 0x04)
-        /// - 128-192 => 0x06
-        /// - 288-32  => 0x07
+        /// Accepted values are chip-dependent:
+        /// - CH32V30X: 192-128, 224-96, 256-64, 128-192, 288-32
+        /// - CH32V20X: 128-64, 144-48, 160-32
         ///
-        /// Also accepted aliases:
-        /// - 192, 224, 256, 128, 288
-        /// - p0, p1, p2, p3, p4
+        /// Raw values are also accepted: 0x00..0x07
         #[arg(
-            value_parser = parse_memory_assign_mode,
             value_name = "MODE",
-            long_help = "SRAM_CODE_MODE value.\n\nAccepted formats:\n  - Hex/raw: 0x00..0x07\n  - Profile aliases: 192-128, 224-96, 256-64, 128-192, 288-32\n  - Compact aliases: 192, 224, 256, 128, 288, p0..p4\n\nProfile to hex mapping:\n  - 192-128 => 0x01 (also 0x00)\n  - 224-96  => 0x03 (also 0x02)\n  - 256-64  => 0x05 (also 0x04)\n  - 128-192 => 0x06\n  - 288-32  => 0x07"
+            long_help = "SRAM_CODE_MODE value.\n\nAliases are interpreted using the detected chip family.\n\nProtocol path by chip:\n  - CH32V30X read/write: 0x0d/0x17 and 0x0d/0x18\n  - CH32V20X read/write: legacy 0x0d/0x04 and 0x0d/0x05\n\nCH32V30X profiles:\n  - 192-128 / p0 / 192 -> writes 0x01 (equivalent read: 0x00 or 0x01)\n  - 224-96  / p1 / 224 -> writes 0x03 (equivalent read: 0x02 or 0x03)\n  - 256-64  / p2 / 256 -> writes 0x05 (equivalent read: 0x04 or 0x05)\n  - 128-192 / p3 / 128 -> writes 0x06\n  - 288-32  / p4 / 288 -> writes 0x07\n\nCH32V20X profiles:\n  - 128-64 / p0 / 128 -> writes 0x00 (equivalent bit-pattern: 0x01)\n  - 144-48 / p1 / 144 -> writes 0x02 (equivalent bit-pattern: 0x03)\n  - 160-32 / p2 / 160 -> writes 0x04 (equivalent bit-patterns: 0x05..0x07; legacy split index is often read back as 0x02)\n\nRaw input:\n  - Hex/raw 0x00..0x07 is always accepted.\n\nExamples:\n  - wlink mem-split set 224-96\n  - wlink mem-split set p1\n  - wlink mem-split set 0x03"
         )]
-        mode: u8,
+        mode: String,
         /// Skip read-back verify after write
         #[arg(long, default_value = "false")]
         no_verify: bool,
     },
 }
 
-fn decode_mcu_memory_assign_mode(mode: u8) -> &'static str {
+fn decode_mcu_mem_split_mode_v30x(mode: u8) -> &'static str {
     match mode & 0x07 {
         0b000 | 0b001 => "CODE-192KB + RAM-128KB",
         0b010 | 0b011 => "CODE-224KB + RAM-96KB",
@@ -221,7 +215,32 @@ fn decode_mcu_memory_assign_mode(mode: u8) -> &'static str {
     }
 }
 
-fn mcu_memory_assign_profile_id(mode: u8) -> u8 {
+fn decode_mcu_mem_split_mode_v20x(mode: u8) -> &'static str {
+    if mode <= 2 {
+        return match mode {
+            0 => "CODE-128KB + RAM-64KB",
+            1 => "CODE-144KB + RAM-48KB",
+            2 => "CODE-160KB + RAM-32KB",
+            _ => "UNKNOWN",
+        };
+    }
+
+    match mode & 0x07 {
+        0b000 | 0b001 => "CODE-128KB + RAM-64KB",
+        0b010 | 0b011 => "CODE-144KB + RAM-48KB",
+        0b100..=0b111 => "CODE-160KB + RAM-32KB",
+        _ => "UNKNOWN",
+    }
+}
+
+fn decode_mcu_mem_split_mode(chip: RiscvChip, mode: u8) -> &'static str {
+    match chip {
+        RiscvChip::CH32V20X => decode_mcu_mem_split_mode_v20x(mode),
+        _ => decode_mcu_mem_split_mode_v30x(mode),
+    }
+}
+
+fn mcu_mem_split_profile_id_v30x(mode: u8) -> u8 {
     match mode & 0x07 {
         0b000 | 0b001 => 0,
         0b010 | 0b011 => 1,
@@ -232,8 +251,29 @@ fn mcu_memory_assign_profile_id(mode: u8) -> u8 {
     }
 }
 
-fn is_same_mcu_memory_assign_profile(expected: u8, observed: u8) -> bool {
-    mcu_memory_assign_profile_id(expected) == mcu_memory_assign_profile_id(observed)
+fn mcu_mem_split_profile_id_v20x(mode: u8) -> u8 {
+    // Legacy read often returns 0..2 index; raw bit patterns can still appear.
+    if mode <= 2 {
+        return mode;
+    }
+
+    match mode & 0x07 {
+        0b000 | 0b001 => 0,
+        0b010 | 0b011 => 1,
+        0b100..=0b111 => 2,
+        _ => 0xff,
+    }
+}
+
+fn mcu_mem_split_profile_id(chip: RiscvChip, mode: u8) -> u8 {
+    match chip {
+        RiscvChip::CH32V20X => mcu_mem_split_profile_id_v20x(mode),
+        _ => mcu_mem_split_profile_id_v30x(mode),
+    }
+}
+
+fn is_same_mcu_mem_split_profile(chip: RiscvChip, expected: u8, observed: u8) -> bool {
+    mcu_mem_split_profile_id(chip, expected) == mcu_mem_split_profile_id(chip, observed)
 }
 
 fn main() -> Result<()> {
@@ -490,33 +530,37 @@ fn main() -> Result<()> {
                         sess.set_sdi_print_enabled(false)?;
                     }
                 },
-                Commands::MemoryAssign { cmd } => match cmd {
-                    MemoryAssign::Get => {
-                        let mode = sess.get_mcu_memory_assign()?;
-                        let profile = decode_mcu_memory_assign_mode(mode);
+                Commands::MemSplit { cmd } => match cmd {
+                    MemSplit::Get => {
+                        let mode = sess.get_mcu_mem_split()?;
+                        let profile = decode_mcu_mem_split_mode(sess.chip_family, mode);
                         log::info!(
-                            "MCU Memory Assign: 0x{:02x} ({})",
+                            "MCU Memory Split: 0x{:02x} ({})",
                             mode,
                             profile
                         );
                         println!("0x{mode:02x} ({profile})");
                     }
-                    MemoryAssign::Set { mode, no_verify } => {
-                        let profile = decode_mcu_memory_assign_mode(mode);
-                        log::info!("Set MCU Memory Assign to 0x{:02x} ({})", mode, profile);
-                        sess.set_mcu_memory_assign(mode)?;
+                    MemSplit::Set { mode, no_verify } => {
+                        let mode = parse_mem_split_mode_for_chip(&mode, sess.chip_family)
+                            .map_err(wlink::Error::Custom)?;
+                        let profile = decode_mcu_mem_split_mode(sess.chip_family, mode);
+                        log::info!("Set MCU Memory Split to 0x{:02x} ({})", mode, profile);
+                        sess.set_mcu_mem_split(mode)?;
 
                         if !no_verify {
-                            let read_back = sess.get_mcu_memory_assign()?;
-                            let read_profile = decode_mcu_memory_assign_mode(read_back);
-                            if !is_same_mcu_memory_assign_profile(mode, read_back) {
+                            let read_back = sess.get_mcu_mem_split()?;
+                            let read_profile =
+                                decode_mcu_mem_split_mode(sess.chip_family, read_back);
+                            if !is_same_mcu_mem_split_profile(sess.chip_family, mode, read_back)
+                            {
                                 return Err(wlink::Error::Custom(format!(
-                                    "MCU Memory Assign verify failed: wrote 0x{mode:02x} ({profile}), read back 0x{read_back:02x} ({read_profile})"
+                                    "MCU Memory Split verify failed: wrote 0x{mode:02x} ({profile}), read back 0x{read_back:02x} ({read_profile})"
                                 ))
                                 .into());
                             }
                             log::info!(
-                                "MCU Memory Assign verified: 0x{:02x} ({})",
+                                "MCU Memory Split verified: 0x{:02x} ({})",
                                 read_back,
                                 read_profile
                             );
@@ -548,17 +592,28 @@ pub fn parse_number(s: &str) -> std::result::Result<u32, String> {
     }
 }
 
-pub fn parse_memory_assign_mode(s: &str) -> std::result::Result<u8, String> {
+pub fn parse_mem_split_mode_for_chip(
+    s: &str,
+    chip: RiscvChip,
+) -> std::result::Result<u8, String> {
     let norm = s.trim().to_lowercase().replace('_', "-");
 
-    let canonical = match norm.as_str() {
-        // profile aliases (CODE-RAM)
-        "192-128" | "192/128" | "192:128" | "192" | "p0" => Some(0x01),
-        "224-96" | "224/96" | "224:96" | "224" | "p1" => Some(0x03),
-        "256-64" | "256/64" | "256:64" | "256" | "p2" => Some(0x05),
-        "128-192" | "128/192" | "128:192" | "128" | "p3" => Some(0x06),
-        "288-32" | "288/32" | "288:32" | "288" | "p4" => Some(0x07),
-        _ => None,
+    let canonical = match chip {
+        RiscvChip::CH32V20X => match norm.as_str() {
+            "128-64" | "128/64" | "128:64" | "128" | "p0" => Some(0x00),
+            "144-48" | "144/48" | "144:48" | "144" | "p1" => Some(0x02),
+            "160-32" | "160/32" | "160:32" | "160" | "p2" => Some(0x04),
+            _ => None,
+        },
+        _ => match norm.as_str() {
+            // profile aliases (CODE-RAM)
+            "192-128" | "192/128" | "192:128" | "192" | "p0" => Some(0x01),
+            "224-96" | "224/96" | "224:96" | "224" | "p1" => Some(0x03),
+            "256-64" | "256/64" | "256:64" | "256" | "p2" => Some(0x05),
+            "128-192" | "128/192" | "128:192" | "128" | "p3" => Some(0x06),
+            "288-32" | "288/32" | "288:32" | "288" | "p4" => Some(0x07),
+            _ => None,
+        },
     };
 
     if let Some(mode) = canonical {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -27,6 +27,45 @@ fn decode_sram_code_mode_v2_v3(mode: u8) -> &'static str {
     }
 }
 
+fn decode_sram_code_mode_v20x(mode: u8) -> &'static str {
+    // Legacy command 0x0d/0x04 often returns compact index 0..2 on CH32V20X.
+    if mode <= 2 {
+        return match mode {
+            0 => "CODE-128KB + RAM-64KB",
+            1 => "CODE-144KB + RAM-48KB",
+            2 => "CODE-160KB + RAM-32KB",
+            _ => "UNKNOWN",
+        };
+    }
+
+    match mode & 0x07 {
+        0b000 | 0b001 => "CODE-128KB + RAM-64KB",
+        0b010 | 0b011 => "CODE-144KB + RAM-48KB",
+        0b100..=0b111 => "CODE-160KB + RAM-32KB",
+        _ => "UNKNOWN",
+    }
+}
+
+fn decode_sram_code_mode(chip: RiscvChip, mode: u8) -> &'static str {
+    match chip {
+        RiscvChip::CH32V20X => decode_sram_code_mode_v20x(mode),
+        _ => decode_sram_code_mode_v2_v3(mode),
+    }
+}
+
+fn v20x_legacy_split_index_from_mode(mode: u8) -> Option<u8> {
+    if mode <= 2 {
+        return Some(mode);
+    }
+
+    Some(match mode & 0x07 {
+        0b000 | 0b001 => 0,
+        0b010 | 0b011 => 1,
+        0b100..=0b111 => 2,
+        _ => return None,
+    })
+}
+
 impl ProbeSession {
     /// Attach probe to target chip, start a probe session
     pub fn attach(probe: WchLink, expected_chip: Option<RiscvChip>, speed: Speed) -> Result<Self> {
@@ -130,12 +169,12 @@ impl ProbeSession {
             }
         }
         if self.chip_family.support_ram_rom_mode() {
-            let sram_code_mode = self.get_mcu_memory_assign()?;
+            let sram_code_mode = self.get_mcu_mem_split()?;
             log::debug!(
                 "SRAM CODE split mode: {} (0x{:02x}, {})",
                 sram_code_mode,
                 sram_code_mode,
-                decode_sram_code_mode_v2_v3(sram_code_mode)
+                decode_sram_code_mode(self.chip_family, sram_code_mode)
             );
         }
         /*
@@ -146,17 +185,17 @@ impl ProbeSession {
         Ok(())
     }
 
-    /// Read MCU memory assignment mode.
+    /// Read MCU memory split mode.
     ///
     /// For CH32V30X, this uses observed official-tool command `0x0d/0x17`.
     /// For other chips that support RAM/ROM mode, it falls back to legacy `0x0d/0x04`.
-    pub fn get_mcu_memory_assign(&mut self) -> Result<u8> {
-        if self.chip_family.support_mcu_memory_assign_cmds() {
-            match self.probe.send_command(commands::control::GetMcuMemoryAssign) {
+    pub fn get_mcu_mem_split(&mut self) -> Result<u8> {
+        if self.chip_family.support_mcu_mem_split_cmds() {
+            match self.probe.send_command(commands::control::GetMcuMemorySplit) {
                 Ok(mode) => return Ok(mode),
                 Err(err) => {
                     log::debug!(
-                        "GetMcuMemoryAssign (0x0d/0x17) failed: {err:?}; trying legacy 0x0d/0x04"
+                        "GetMcuMemorySplit (0x0d/0x17) failed: {err:?}; trying legacy 0x0d/0x04"
                     );
                 }
             }
@@ -166,28 +205,41 @@ impl ProbeSession {
             .send_command(commands::control::GetChipRomRamSplit)
     }
 
-    /// Set MCU memory assignment mode via observed command `0x0d/0x18`.
+    /// Set MCU memory split mode via observed command `0x0d/0x18`.
     ///
-    /// Safety gate: currently enabled only for CH32V30X.
-    pub fn set_mcu_memory_assign(&mut self, mode: u8) -> Result<()> {
-        if !self.chip_family.support_mcu_memory_assign_cmds() {
-            return Err(Error::Custom(format!(
-                "MCU Memory Assign set (0x0d/0x18) is enabled only for CH32V30X, attached: {:?}",
-                self.chip_family
-            )));
+    /// Uses chip-specific protocol:
+    /// - CH32V30X: `0x0d/0x18`
+    /// - CH32V20X: legacy `0x0d/0x05`
+    pub fn set_mcu_mem_split(&mut self, mode: u8) -> Result<()> {
+        if self.chip_family.support_mcu_mem_split_cmds() {
+            let ack = self
+                .probe
+                .send_command(commands::control::SetMcuMemorySplit(mode))?;
+
+            if ack != 0x18 {
+                return Err(Error::Custom(format!(
+                    "Unexpected MCU Memory Split ACK: 0x{ack:02x}"
+                )));
+            }
+
+            return Ok(());
         }
 
-        let ack = self
-            .probe
-            .send_command(commands::control::SetMcuMemoryAssign(mode))?;
-
-        if ack != 0x18 {
-            return Err(Error::Custom(format!(
-                "Unexpected MCU Memory Assign ACK: 0x{ack:02x}"
-            )));
+        if self.chip_family.support_mcu_mem_split_legacy_cmds() {
+            let split_idx = v20x_legacy_split_index_from_mode(mode).ok_or_else(|| {
+                Error::Custom(format!(
+                    "Invalid CH32V20X memory split mode: 0x{mode:02x} (expected profile index 0..2 or raw 0x00..0x07)"
+                ))
+            })?;
+            self.probe
+                .send_command(commands::control::SetChipRomRamSplit(split_idx))?;
+            return Ok(());
         }
 
-        Ok(())
+        Err(Error::Custom(format!(
+            "MCU Memory Split set is enabled for CH32V30X and CH32V20X only, attached: {:?}",
+            self.chip_family
+        )))
     }
 
     pub fn unprotect_flash(&mut self) -> Result<()> {

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -16,6 +16,17 @@ pub struct ProbeSession {
     pub speed: Speed,
 }
 
+fn decode_sram_code_mode_v2_v3(mode: u8) -> &'static str {
+    match mode & 0x07 {
+        0b000 | 0b001 => "CODE-192KB + RAM-128KB",
+        0b010 | 0b011 => "CODE-224KB + RAM-96KB",
+        0b100 | 0b101 => "CODE-256KB + RAM-64KB",
+        0b110 => "CODE-128KB + RAM-192KB",
+        0b111 => "CODE-288KB + RAM-32KB",
+        _ => "UNKNOWN",
+    }
+}
+
 impl ProbeSession {
     /// Attach probe to target chip, start a probe session
     pub fn attach(probe: WchLink, expected_chip: Option<RiscvChip>, speed: Speed) -> Result<Self> {
@@ -119,16 +130,63 @@ impl ProbeSession {
             }
         }
         if self.chip_family.support_ram_rom_mode() {
-            let sram_code_mode = self
-                .probe
-                .send_command(commands::control::GetChipRomRamSplit)?;
-            log::debug!("SRAM CODE split mode: {}", sram_code_mode);
+            let sram_code_mode = self.get_mcu_memory_assign()?;
+            log::debug!(
+                "SRAM CODE split mode: {} (0x{:02x}, {})",
+                sram_code_mode,
+                sram_code_mode,
+                decode_sram_code_mode_v2_v3(sram_code_mode)
+            );
         }
         /*
         if detailed {
 
         }
         */
+        Ok(())
+    }
+
+    /// Read MCU memory assignment mode.
+    ///
+    /// For CH32V30X, this uses observed official-tool command `0x0d/0x17`.
+    /// For other chips that support RAM/ROM mode, it falls back to legacy `0x0d/0x04`.
+    pub fn get_mcu_memory_assign(&mut self) -> Result<u8> {
+        if self.chip_family.support_mcu_memory_assign_cmds() {
+            match self.probe.send_command(commands::control::GetMcuMemoryAssign) {
+                Ok(mode) => return Ok(mode),
+                Err(err) => {
+                    log::debug!(
+                        "GetMcuMemoryAssign (0x0d/0x17) failed: {err:?}; trying legacy 0x0d/0x04"
+                    );
+                }
+            }
+        }
+
+        self.probe
+            .send_command(commands::control::GetChipRomRamSplit)
+    }
+
+    /// Set MCU memory assignment mode via observed command `0x0d/0x18`.
+    ///
+    /// Safety gate: currently enabled only for CH32V30X.
+    pub fn set_mcu_memory_assign(&mut self, mode: u8) -> Result<()> {
+        if !self.chip_family.support_mcu_memory_assign_cmds() {
+            return Err(Error::Custom(format!(
+                "MCU Memory Assign set (0x0d/0x18) is enabled only for CH32V30X, attached: {:?}",
+                self.chip_family
+            )));
+        }
+
+        let ack = self
+            .probe
+            .send_command(commands::control::SetMcuMemoryAssign(mode))?;
+
+        if ack != 0x18 {
+            return Err(Error::Custom(format!(
+                "Unexpected MCU Memory Assign ACK: 0x{ack:02x}"
+            )));
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Hi!
I know how it looks.
Yes, I don't have a clue how to program in rust and yes it is vibe coded.
But I just needed to be able to switch between various memory split models using wlink just like official WCH tools are able to.
So I plugged WCH-link to my USB Packet viewer, connected a devboard with CH32V307 and dumped transmission from few sets and gets of memory assignments.
Then I chatted with GPT-5.3-Codex and it parsed the logs, broke down the transmission, found that for this function is responsible a pair of 0x0d/0x17 and 0x0d/0x18 commands and added implementation of new `mem-split` CLI command.
I tested it on a bunch of CH32V30X chips I have and it works. I don't have CH32V20X so I don't know how it will behave there, especially as GPT decided to use old  0x0d/0x04 and 0x0d/0x05 commads documented in protocol.md for it.
If someone would like to test it I made a release on my fork.
I have no idea whether it resulted with a good rust so I won't be worried if this PR will be declined but it would be great to add such function to main based on my research. I can add dumps of USB comminication and scripts to parse it when needed.
In case of a review I'd be happy to help but only I can do is to give it to the chat and hope that it will produce something ok-ish enough, as I said I don't speak rust :)
