### PR TITLE
Add ch32v4x7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Current firmware version: 2.15 (aka. v35).
 - [CH32X035]/CH32X033
 - [CH32L103]
 - [CH32H417]
+- [CH32V407]
+- [CH32V467]
 - [ ] [CH8571] - No other source about this chip, help wanted
 - ... (Feel free to open an issue if you have tested on other chips)
 
@@ -89,6 +91,8 @@ Current firmware version: 2.15 (aka. v35).
 [CH643]: https://www.wch-ic.com/products/CH643.html
 [CH8571]: https://www.wch.cn/news/606.html
 [CH32H417]: https://www.wch-ic.com/products/CH32H417.html
+[CH32V407]: https://www.wch.cn/products/CH32V407.html
+[CH32V467]: https://www.wch.cn/products/CH32V407.html
 
 ## Install
 

--- a/src/chips.rs
+++ b/src/chips.rs
@@ -118,6 +118,15 @@ pub fn chip_id_to_chip_name(chip_id: u32) -> Option<&'static str> {
             0x317_5B508 => Some("CH32V317TCU6"),
             _ => None,
         },
+        0x467_00000 => match chip_id & !0x0000_00F0 {
+            0x4670_0000 => Some("CH32V407VET"),
+            0x4671_0001 => Some("CH32V407WEU"),
+            0x4672_0002 => Some("CH32V407RET"),
+            0x4673_0000 => Some("CH32V467VET"),
+            0x4674_0001 => Some("CH32V467WEU"),
+            0x4675_0002 => Some("CH32V467RET"),
+            _ => None,
+        },
         // https://github.com/openwch/ch32h417/blob/main/EVT/EXAM/SRC/Peripheral/src/ch32h417_dbgmcu.c
         0x415_00000 | 0x416_00000 | 0x417_00000 => match chip_id & !0x0000_00F0 {
             0x415_0050D => Some("CH32H415REU"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub enum RiscvChip {
     CH645 = 0x46,
     /// CH32V317 RISC-V4 series
     CH32V317 = 0x86,
+    /// CH32V407/CH32V467 RISC-V4 series
+    CH32V4X7 = 0xa6,
     // Cortex-M chips
     CH32F10X = 0x04,
     CH32F20X = 0x08,
@@ -88,6 +90,7 @@ impl ValueEnum for RiscvChip {
             RiscvChip::CH32V00X,
             RiscvChip::CH645,
             RiscvChip::CH32V317,
+            RiscvChip::CH32V4X7,
             RiscvChip::CH32H41X,
         ]
     }
@@ -112,6 +115,10 @@ impl ValueEnum for RiscvChip {
             RiscvChip::CH32V00X => Some(PossibleValue::new("CH32V00X")),
             RiscvChip::CH645 => Some(PossibleValue::new("CH645")),
             RiscvChip::CH32V317 => Some(PossibleValue::new("CH32V317")),
+            RiscvChip::CH32V4X7 => Some(PossibleValue::new("CH32V4X7").aliases([
+                "CH32V407",
+                "CH32V467",
+            ])),
             RiscvChip::CH32H41X => Some(PossibleValue::new("CH32H41X").aliases([
                 "CH32H415",
                 "CH32H415REU",
@@ -142,6 +149,7 @@ impl ValueEnum for RiscvChip {
             "CH32V20X" | "CH32V203" | "CH32V208" => Ok(RiscvChip::CH32V20X),
             "CH32V30X" | "CH32V303" | "CH32V305" | "CH32V307" => Ok(RiscvChip::CH32V30X),
             "CH32V317" => Ok(RiscvChip::CH32V317),
+            "CH32V4X7" | "CH32V407" | "CH32V467" => Ok(RiscvChip::CH32V4X7),
             "CH32V003" => Ok(RiscvChip::CH32V003),
             "CH32L103" => Ok(RiscvChip::CH32L103),
             // Note that CH32X034 seems never released
@@ -197,6 +205,7 @@ impl RiscvChip {
                 | RiscvChip::CH641
                 | RiscvChip::CH645
                 | RiscvChip::CH32V317
+                | RiscvChip::CH32V4X7
                 | RiscvChip::CH32H41X
         )
     }
@@ -205,7 +214,7 @@ impl RiscvChip {
     pub(crate) fn support_ram_rom_mode(&self) -> bool {
         matches!(
             self,
-            RiscvChip::CH32V20X | RiscvChip::CH32V30X | RiscvChip::CH32V317
+            RiscvChip::CH32V20X | RiscvChip::CH32V30X | RiscvChip::CH32V317 | RiscvChip::CH32V4X7
         )
     }
 
@@ -262,6 +271,7 @@ impl RiscvChip {
                 | RiscvChip::CH643
                 | RiscvChip::CH641
                 | RiscvChip::CH32V317
+                | RiscvChip::CH32V4X7
         )
     }
 
@@ -329,7 +339,7 @@ impl RiscvChip {
             RiscvChip::CH564 => &flash_op::CH564,
             RiscvChip::CH32V00X => &flash_op::CH32V00X,
             RiscvChip::CH645 => &flash_op::CH645,
-            RiscvChip::CH32V317 => &flash_op::CH32V317,
+            RiscvChip::CH32V317 | RiscvChip::CH32V4X7 => &flash_op::CH32V317,
             RiscvChip::CH32F10X => todo!(),
             RiscvChip::CH32F20X => todo!(),
             RiscvChip::CH32H41X => &flash_op::CH32H417,
@@ -355,6 +365,7 @@ impl RiscvChip {
             0x4E => Ok(RiscvChip::CH32V00X),
             0x46 => Ok(RiscvChip::CH645),
             0x86 => Ok(RiscvChip::CH32V317),
+            0xa6 => Ok(RiscvChip::CH32V4X7),
             0x04 => Ok(RiscvChip::CH32F10X),
             0x08 => Ok(RiscvChip::CH32F20X),
             0xC6 => Ok(RiscvChip::CH32H41X),


### PR DESCRIPTION
Flashing Log:

> wlink flash .pio/build/genericCH32V407VET6/firmware.elf
> 12:52:31 [INFO] Connected to WCH-Link v2.21(v41) (WCH-LinkE-CH32V305)
> 12:52:32 [INFO] Attached chip: CH32V4X7 [CH32V407VET] (ChipID: 0x46700000)
> 12:52:32 [INFO] Chip ESIG: FlashSize(576KB) UID(1a-06-ad-50-6c-54-33-ab)
> 12:52:32 [INFO] Flash protected: false
> 12:52:32 [INFO] Read .pio/build/genericCH32V407VET6/firmware.elf as ELF format
> 12:52:32 [INFO] Flashing 16544 bytes to 0x08000000
> 12:52:32 [INFO] Read protected: false
> ███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████ 16544/16544
> 12:52:32 [INFO] Flash done
> 12:52:33 [INFO] Now reset...